### PR TITLE
Add support to composite key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,60 @@ Or install it yourself as:
   - [x] .limit
   - [x] .offset
 
+## To use
+
+### Create entity and repository
+
+```ruby
+class User
+  include Hanami::Entity
+  attributes :id, :name, :age
+end
+
+class UserRepository
+  include Hanami::Repository
+end
+```
+
+### Configure your mapping
+
+**Important**: Use our `coerce` for your key.
+
+```ruby
+collection :users do
+  entity     User
+  repository UserRepository
+
+  attribute :id,   Hanami::Gcloud::Datastore::Coercers::Key
+  attribute :name, String
+  attribute :age,  Integer, as: :Age
+end
+```
+
+### Now... use! (:
+
+```ruby
+# getting first
+UserRepository.first
+# => nil
+
+# creating an user
+user = User.new(name: 'Leonardo', age: 7)
+user = UserRepository.create(user)
+# => #<User:0x007fef032a3920 @id="WyJVc2VyIiwyMix7InByb2plY3QiOiJ0ZXN0aW5nLXByb2plY3QifV0=\n" @name="Leonardo" @age=7>
+
+# getting the user
+user = UserRepository.find(user.id)
+# => #<User:0x007fef02c0cc10 @id="WyJVc2VyIiwyMyx7InByb2plY3QiOiJ0ZXN0aW5nLXByb2plY3QifV0=\n" @name="Leonardo" @age=7>
+
+# composite key
+id = Hanami::Gcloud::Datastore::Coercers::Key.create('User', '1', namespace: 'my-namespace')
+# => "WyJVc2VyIiwiMSIseyJuYW1lc3BhY2UiOiJteS1uYW1lc3BhY2UifV0=\n"
+user = User.new(id: id, name: 'Leonardo', age: 7)
+user = UserRepository.persist(user)
+# => #<User:0x007fef032a3920 @id="WyJVc2VyIiwyMix7InByb2plY3QiOiJ0ZXN0aW5nLXByb2plY3QifV0=\n" @name="Leonardo" @age=7>
+```
+
 ## Testing
 
 To run tests locally is necessary download the gcd and run:

--- a/lib/hanami-gcloud-datastore.rb
+++ b/lib/hanami-gcloud-datastore.rb
@@ -1,2 +1,3 @@
 require 'hanami/model'
+require 'hanami/gcloud/datastore/coercers/key'
 require 'hanami/model/adapters/gcloud/datastore_adapter'

--- a/lib/hanami/gcloud/datastore/coercers/key.rb
+++ b/lib/hanami/gcloud/datastore/coercers/key.rb
@@ -1,0 +1,66 @@
+require 'hanami/model/coercer'
+require 'base64'
+require 'json'
+require 'gcloud/datastore/key'
+
+module Hanami
+  module Gcloud
+    module Datastore
+      module Coercers
+        class Key < Hanami::Model::Coercer
+          def initialize(value)
+            @value = value
+          end
+
+          def self.dump(value)
+            new(value).dump
+          end
+
+          def dump
+            deserialize_key(*JSON.parse(Base64.decode64(@value)))
+          rescue
+            nil
+          end
+
+          def self.load(value)
+            new(value).load
+          end
+
+          def load
+            Base64.encode64(serialize_key(@value).to_json.to_s)
+          end
+
+          def self.create(*value)
+            new(value).create
+          end
+
+          def create
+            Base64.encode64(@value.to_json.to_s)
+          end
+
+          private
+
+          def serialize_key(value)
+            _key = [value.kind, value.id || value.name]
+
+            opts = {}
+            opts['parent']    = serialize_key(value.parent) if !value.parent.nil?
+            opts['namespace'] = value.namespace if !value.namespace.nil? && !value.namespace.empty?
+            opts['project']   = value.project if !value.project.nil?
+            _key << opts if !opts.empty?
+
+            _key
+          end
+
+          def deserialize_key(kind, id, opts = {})
+            key = ::Gcloud::Datastore::Key.new kind, id
+            key.namespace = opts['namespace'] if opts.include? 'namespace'
+            key.project = opts['project'] if opts.include? 'project'
+            key.parent = deserialize_key(*opts['parent']) if opts.include? 'parent'
+            key
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/model/adapters/gcloud/datastore/collection.rb
+++ b/lib/hanami/model/adapters/gcloud/datastore/collection.rb
@@ -42,7 +42,8 @@ module Hanami
                 end
               end
 
-              entity.id = @dataset.save(persist_entity).first.key.id
+              saved = @dataset.save(persist_entity).first
+              entity.id = saved.key.id || saved.key.name
               entity
             end
 
@@ -117,7 +118,7 @@ module Hanami
             # @api private
             # @since 0.1.0
             def key_for(entity)
-              @dataset.key kind, entity.id
+              @dataset.key kind, entity.public_send(@mapped_collection.identity)
             end
 
             # Serialize the given entity before to persist in the datastore.
@@ -144,7 +145,7 @@ module Hanami
                   end
 
                   hash
-                end.merge(id: entity.key.id || entity.key.name)
+                end.merge(@mapped_collection.identity => entity.key.id || entity.key.name)
               )
             end
           end

--- a/test/coercers_test.rb
+++ b/test/coercers_test.rb
@@ -1,0 +1,147 @@
+require 'test_helper'
+
+describe Hanami::Gcloud::Datastore::Coercers::Key do
+  let(:parent_parent) do
+    key = Gcloud::Datastore::Key.new('ParentParent', 'parent-parent')
+    key.project = 'project'
+    key
+  end
+
+  let(:parent) do
+    key = Gcloud::Datastore::Key.new('Parent', 'parent')
+    key.namespace = 'namespace-parent'
+    key.parent = parent_parent
+    key.project = 'project'
+    key
+  end
+
+  let(:entity) do
+    key = Gcloud::Datastore::Key.new('Kind', 'id')
+    key.parent = parent
+    key.namespace = 'namespace'
+    key.project = 'project'
+    key
+  end
+
+  let(:parametrized_parent_parent) do
+    [parent_parent.kind, parent_parent.name, { 'project' => parent_parent.project }]
+  end
+
+  let(:encoded_parent_parent) do
+    Base64.encode64(parametrized_parent_parent.to_json)
+  end
+
+  let(:parametrized_parent) do
+    [
+      parent.kind,
+      parent.name,
+      {
+        'parent' => parametrized_parent_parent,
+        'namespace' => 'namespace-parent',
+        'project' => parent.project
+      },
+    ]
+  end
+
+  let(:encoded_parent) do
+    Base64.encode64(parametrized_parent.to_json)
+  end
+
+  let(:parametrized_entity) do
+    [
+      'Kind',
+      'id',
+      {
+        'parent' => parametrized_parent,
+        'namespace' => 'namespace',
+        'project' => entity.project
+      }
+    ]
+  end
+
+  let(:encoded_entity) do
+    Base64.encode64(parametrized_entity.to_json)
+  end
+
+  describe '.create' do
+    let(:key_parent_parent) { ['ParentParent', 'parent-parent', 'project' => 'project'] }
+    let(:key_parent) { ['Parent', 'parent', 'parent' => key_parent_parent, 'namespace' => 'namespace-parent', 'project' => 'project'] }
+    let(:key_entity) { ['Kind', 'id', 'parent' => key_parent, 'namespace' => 'namespace', 'project' => 'project'] }
+
+    it 'simple kind and name' do
+      subject = Hanami::Gcloud::Datastore::Coercers::Key.create(*key_parent_parent)
+      subject.must_equal encoded_parent_parent
+    end
+
+    it 'with kind, name and one level of parent' do
+      subject = Hanami::Gcloud::Datastore::Coercers::Key.create(*key_parent)
+      subject.must_equal encoded_parent
+    end
+
+    it 'with kind, name and two levels of parent' do
+      subject = Hanami::Gcloud::Datastore::Coercers::Key.create(*key_entity)
+      subject.must_equal encoded_entity
+    end
+  end
+
+  describe '.dump' do
+    it 'simple kind and name' do
+      subject = Hanami::Gcloud::Datastore::Coercers::Key.dump(encoded_parent_parent)
+
+      subject.kind.must_equal parent_parent.kind
+      subject.name.must_equal parent_parent.name
+      subject.project.must_equal parent_parent.project
+      subject.namespace.must_be_nil
+    end
+
+    it 'with kind, name and one level of parent' do
+      subject = Hanami::Gcloud::Datastore::Coercers::Key.dump(encoded_parent)
+
+      subject.kind.must_equal parent.kind
+      subject.name.must_equal parent.name
+      subject.project.must_equal parent.project
+      subject.namespace.must_equal parent.namespace
+
+      subject.parent.kind.must_equal parent_parent.kind
+      subject.parent.name.must_equal parent_parent.name
+      subject.parent.project.must_equal parent_parent.project
+      subject.parent.namespace.must_be_nil
+    end
+
+    it 'with kind, name and two levels of parent' do
+      subject = Hanami::Gcloud::Datastore::Coercers::Key.dump(encoded_entity)
+
+      subject.kind.must_equal entity.kind
+      subject.name.must_equal entity.name
+      subject.project.must_equal entity.project
+      subject.namespace.must_equal entity.namespace
+
+      subject.parent.kind.must_equal parent.kind
+      subject.parent.name.must_equal parent.name
+      subject.parent.project.must_equal parent.project
+      subject.parent.namespace.must_equal parent.namespace
+
+      subject.parent.parent.kind.must_equal parent_parent.kind
+      subject.parent.parent.name.must_equal parent_parent.name
+      subject.parent.parent.project.must_equal parent_parent.project
+      subject.parent.parent.namespace.must_be_nil
+    end
+  end
+
+  describe '.load' do
+    it 'simple kind and name' do
+      subject = Hanami::Gcloud::Datastore::Coercers::Key.load(parent_parent)
+      subject.must_equal encoded_parent_parent
+    end
+
+    it 'with kind, name and one level of parent' do
+      subject = Hanami::Gcloud::Datastore::Coercers::Key.load(parent)
+      subject.must_equal encoded_parent
+    end
+
+    it 'with kind, name and two levels of parent' do
+      subject = Hanami::Gcloud::Datastore::Coercers::Key.load(entity)
+      subject.must_equal encoded_entity
+    end
+  end
+end

--- a/test/model/adapters/gcloud/datastore_adapter_test.rb
+++ b/test/model/adapters/gcloud/datastore_adapter_test.rb
@@ -13,9 +13,10 @@ describe Hanami::Model::Adapters::Gcloud::DatastoreAdapter do
 
     @mapper = Hanami::Model::Mapper.new do
       collection :test_users do
-        entity TestUser
+        entity     TestUser
+        repository TestUserRepository
 
-        attribute :id,   String
+        attribute :id,   Hanami::Gcloud::Datastore::Coercers::Key
         attribute :name, String
         attribute :age,  Integer, as: :Age
       end
@@ -53,7 +54,8 @@ describe Hanami::Model::Adapters::Gcloud::DatastoreAdapter do
   end
 
   describe '#update' do
-    let(:entity) { TestUser.new(id: 2, name: 'test', age: 30) }
+    let(:key) { Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 2, { 'project' => ENV['DATASTORE_DATASET'] }) }
+    let(:entity) { TestUser.new(id: key, name: 'test', age: 30) }
 
     it 'updates the entity' do
       old_entity = @adapter.create(collection, entity)
@@ -72,7 +74,8 @@ describe Hanami::Model::Adapters::Gcloud::DatastoreAdapter do
   end
 
   describe '#persist' do
-    let(:entity) { TestUser.new(id: 3, name: 'test', age: 30) }
+    let(:key) { Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 3, { 'project' => ENV['DATASTORE_DATASET'] }) }
+    let(:entity) { TestUser.new(id: key, name: 'test', age: 30) }
 
     it 'updates the entity' do
       old_entity = @adapter.persist(collection, entity)
@@ -91,7 +94,8 @@ describe Hanami::Model::Adapters::Gcloud::DatastoreAdapter do
   end
 
   describe '#find' do
-    let(:entity) { TestUser.new(id: 4, name: 'test', age: 30) }
+    let(:key) { Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 4, { 'project' => ENV['DATASTORE_DATASET'] }) }
+    let(:entity) { TestUser.new(id: key, name: 'test', age: 30) }
 
     it 'when no entity are persisted' do
       @adapter.find(collection, -8).must_equal nil
@@ -105,7 +109,8 @@ describe Hanami::Model::Adapters::Gcloud::DatastoreAdapter do
   end
 
   describe '#delete' do
-    let(:entity) { TestUser.new(id: 5, name: 'test', age: 30) }
+    let(:key) { Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 5, { 'project' => ENV['DATASTORE_DATASET'] }) }
+    let(:entity) { TestUser.new(id: key, name: 'test', age: 30) }
 
     it 'when entity are persisted' do
       subject = @adapter.create(collection, entity)
@@ -117,10 +122,14 @@ describe Hanami::Model::Adapters::Gcloud::DatastoreAdapter do
   end
 
   describe '#query' do
-    let(:entity_1) { TestUser.new(id: 31, name: 'test #1', age: 31) }
-    let(:entity_2) { TestUser.new(id: 32, name: 'test #2', age: 32) }
-    let(:entity_3) { TestUser.new(id: 33, name: 'test #3', age: 33) }
-    let(:entity_4) { TestUser.new(id: 34, name: 'test #4', age: 34) }
+    let(:key_1) { Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 31, { 'project' => ENV['DATASTORE_DATASET'] }) }
+    let(:key_2) { Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 32, { 'project' => ENV['DATASTORE_DATASET'] }) }
+    let(:key_3) { Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 33, { 'project' => ENV['DATASTORE_DATASET'] }) }
+    let(:key_4) { Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 34, { 'project' => ENV['DATASTORE_DATASET'] }) }
+    let(:entity_1) { TestUser.new(id: key_1, name: 'test #1', age: 31) }
+    let(:entity_2) { TestUser.new(id: key_2, name: 'test #2', age: 32) }
+    let(:entity_3) { TestUser.new(id: key_3, name: 'test #3', age: 33) }
+    let(:entity_4) { TestUser.new(id: key_4, name: 'test #4', age: 34) }
 
     it 'when operator is equal' do
       entities = [entity_1, entity_2, entity_3, entity_4]
@@ -239,9 +248,12 @@ describe Hanami::Model::Adapters::Gcloud::DatastoreAdapter do
     end
 
     it 'returns first element based on key order' do
-      entity_1 = TestUser.new(id: 31, name: 'test #1', age: 31)
-      entity_2 = TestUser.new(id: 32, name: 'test #2', age: 32)
-      entity_3 = TestUser.new(id: 33, name: 'test #3', age: 33)
+      key_1    = Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 31, { 'project' => ENV['DATASTORE_DATASET'] })
+      key_2    = Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 32, { 'project' => ENV['DATASTORE_DATASET'] })
+      key_3    = Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 33, { 'project' => ENV['DATASTORE_DATASET'] })
+      entity_1 = TestUser.new(id: key_1, name: 'test #1', age: 31)
+      entity_2 = TestUser.new(id: key_2, name: 'test #2', age: 32)
+      entity_3 = TestUser.new(id: key_3, name: 'test #3', age: 33)
 
       entities = [entity_3, entity_1, entity_2]
       added_entities = entities.map { |e| @adapter.create(collection, e) }
@@ -260,9 +272,12 @@ describe Hanami::Model::Adapters::Gcloud::DatastoreAdapter do
     end
 
     it 'returns last element based on key order' do
-      entity_1 = TestUser.new(id: 31, name: 'test #1', age: 31)
-      entity_2 = TestUser.new(id: 32, name: 'test #2', age: 32)
-      entity_3 = TestUser.new(id: 33, name: 'test #3', age: 33)
+      key_1    = Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 31, { 'project' => ENV['DATASTORE_DATASET'] })
+      key_2    = Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 32, { 'project' => ENV['DATASTORE_DATASET'] })
+      key_3    = Hanami::Gcloud::Datastore::Coercers::Key.create('TestUser', 33, { 'project' => ENV['DATASTORE_DATASET'] })
+      entity_1 = TestUser.new(id: key_1, name: 'test #1', age: 31)
+      entity_2 = TestUser.new(id: key_2, name: 'test #2', age: 32)
+      entity_3 = TestUser.new(id: key_3, name: 'test #3', age: 33)
 
       entities = [entity_3, entity_1, entity_2]
       added_entities = entities.map { |e| @adapter.create(collection, e) }


### PR DESCRIPTION
```ruby
id = Hanami::Gcloud::Datastore::Coercers::Key.create('User', '1', namespace: 'my-namespace')
user = User.new(id: id, name: 'Leonardo', age: 7)
user = UserRepository.persist(user)
```

To more details, [see](https://github.com/b2beauty/hanami-gcloud-datastore/blob/abc53d130eaabe14dd3ce113a627949b20f7067f/README.md#to-use)

Resolves #10 and resolves partially #15 
